### PR TITLE
Issue #22: add hook_tfa_login_denied

### DIFF
--- a/tfa.api.php
+++ b/tfa.api.php
@@ -176,6 +176,11 @@ function hook_tfa_ready_require($account) {
  * denied under the conditions of the account not having TFA set up. TFA module
  * will have already invoked 'ready' methods on enabled plugins.
  *
+ * Return TRUE or FALSE only. Don't set messages or change state here: TFA
+ * calls every implementation and lets the login through if any returns TRUE,
+ * so side effects can fire on logins another module allowed. Use
+ * hook_tfa_login_denied() to set deny messages.
+ *
  * @param User $account
  *   User account.
  *
@@ -184,4 +189,21 @@ function hook_tfa_ready_require($account) {
  */
 function hook_tfa_skip_require($account) {
   return TRUE;
+}
+
+/**
+ * Act when TFA enforcement denies a login.
+ *
+ * Invoked at the deny site after hook_tfa_skip_require has been collected from
+ * every implementation and no implementation granted a bypass. Use this hook
+ * to set a user-facing message explaining the denial, log the event, or take
+ * other action before the user is redirected away.
+ *
+ * By the time this hook fires the deny is committed — implementations cannot
+ * allow the login through.
+ *
+ * @param User $account
+ *   User account whose login is being denied.
+ */
+function hook_tfa_login_denied($account) {
 }

--- a/tfa.module
+++ b/tfa.module
@@ -339,6 +339,8 @@ function tfa_login_submit($form, &$form_state) {
         user_login_submit($form, $form_state);
         return;
       }
+      // Let modules set a deny message or take other action.
+      module_invoke_all('tfa_login_denied', $account);
       $form_state['redirect'] = !empty($form_state['redirect']) ? $form_state['redirect'] : 'user';
       return;
     }
@@ -424,6 +426,7 @@ function tfa_user_login(&$edit, $account) {
       if (!empty($skip_require_tfa)) {
         return;
       }
+      module_invoke_all('tfa_login_denied', $account);
       tfa_logout();
       backdrop_goto('user');
     }


### PR DESCRIPTION
Fixes #22.

Adds `hook_tfa_login_denied($account)` invoked at both deny sites in `tfa.module` (after `module_invoke_all('tfa_skip_require')` returns no TRUE), so plugin modules can set deny messages or take other action without polluting `hook_tfa_skip_require` with side effects.

Also expands the `hook_tfa_skip_require` docblock to spell out the "return TRUE/FALSE only" contract so future implementations don't reintroduce the same pattern.

Existing `hook_tfa_skip_require` implementations see no behavior change unless they relied on side effects firing inside the predicate.

Companion: backdrop-contrib/tfa_basic#27 + PR (consumes this new hook).